### PR TITLE
Add Example Capacitive Touch paint

### DIFF
--- a/examples/CapTouchPaint/CapTouchPaint.ino
+++ b/examples/CapTouchPaint/CapTouchPaint.ino
@@ -1,0 +1,134 @@
+/***************************************************
+  This is our touchscreen painting example for the Adafruit ILI9341
+  captouch shield
+  ----> http://www.adafruit.com/products/1947
+
+  Check out the links above for our tutorials and wiring diagrams
+
+  Adafruit invests time and resources providing this open source code,
+  please support Adafruit and open-source hardware by purchasing
+  products from Adafruit!
+
+  Written by Limor Fried/Ladyada for Adafruit Industries.
+  MIT license, all text above must be included in any redistribution
+ ****************************************************/
+
+
+#include <SPI.h>       // this is needed for display
+#include <ILI9488_t3.h>
+#include <Wire.h>      // this is needed for FT6206
+#include <Adafruit_FT6206.h>
+
+// The FT6206 uses hardware I2C (SCL/SDA)
+Adafruit_FT6206 ctp = Adafruit_FT6206();
+
+// The display also uses hardware SPI, plus #9 & #10
+#define TFT_RST 8
+#define TFT_DC 9
+#define TFT_CS 10
+#define TFT_BL 7
+ILI9488_t3 tft = ILI9488_t3(&SPI, TFT_CS, TFT_DC, TFT_RST);
+
+// Size of the color selection boxes and the paintbrush size
+#define BOXSIZE 40
+#define PENRADIUS 3
+int oldcolor, currentcolor;
+
+void setup(void) {
+  while (!Serial);     // used for leonardo debugging
+ 
+  Serial.begin(115200);
+  Serial.println(F("Cap Touch Paint!"));
+  
+  tft.begin();
+
+  if (! ctp.begin(40)) {  // pass in 'sensitivity' coefficient
+    Serial.println("Couldn't start FT6206 touchscreen controller");
+    while (1);
+  }
+
+  Serial.println("Capacitive touchscreen started");
+  
+  tft.fillScreen(ILI9488_BLACK);
+  
+  // make the color selection boxes
+  tft.fillRect(0, 0, BOXSIZE, BOXSIZE, ILI9488_RED);
+  tft.fillRect(BOXSIZE, 0, BOXSIZE, BOXSIZE, ILI9488_YELLOW);
+  tft.fillRect(BOXSIZE*2, 0, BOXSIZE, BOXSIZE, ILI9488_GREEN);
+  tft.fillRect(BOXSIZE*3, 0, BOXSIZE, BOXSIZE, ILI9488_CYAN);
+  tft.fillRect(BOXSIZE*4, 0, BOXSIZE, BOXSIZE, ILI9488_BLUE);
+  tft.fillRect(BOXSIZE*5, 0, BOXSIZE, BOXSIZE, ILI9488_MAGENTA);
+ 
+  // select the current color 'red'
+  tft.drawRect(0, 0, BOXSIZE, BOXSIZE, ILI9488_WHITE);
+  currentcolor = ILI9488_RED;
+}
+
+void loop() {
+  // Wait for a touch
+  if (! ctp.touched()) {
+    return;
+  }
+
+  // Retrieve a point  
+  TS_Point p = ctp.getPoint();
+  
+ 
+  // Print out raw data from screen touch controller
+  /*
+  Serial.print("X = "); Serial.print(p.x);
+  Serial.print("\tY = "); Serial.print(p.y);
+  Serial.print(" -> ");
+ 
+// Maybe flip it around to match the screen.
+//  p.x = map(p.x, 0, 240, 240, 0);
+//  p.y = map(p.y, 0, 320, 320, 0);
+
+  // Print out the remapped (rotated) coordinates
+  Serial.print("("); Serial.print(p.x);
+  Serial.print(", "); Serial.print(p.y);
+  Serial.println(")");
+  */
+
+  if (p.y < BOXSIZE) {
+     oldcolor = currentcolor;
+
+     if (p.x < BOXSIZE) { 
+       currentcolor = ILI9488_RED; 
+       tft.drawRect(0, 0, BOXSIZE, BOXSIZE, ILI9488_WHITE);
+     } else if (p.x < BOXSIZE*2) {
+       currentcolor = ILI9488_YELLOW;
+       tft.drawRect(BOXSIZE, 0, BOXSIZE, BOXSIZE, ILI9488_WHITE);
+     } else if (p.x < BOXSIZE*3) {
+       currentcolor = ILI9488_GREEN;
+       tft.drawRect(BOXSIZE*2, 0, BOXSIZE, BOXSIZE, ILI9488_WHITE);
+     } else if (p.x < BOXSIZE*4) {
+       currentcolor = ILI9488_CYAN;
+       tft.drawRect(BOXSIZE*3, 0, BOXSIZE, BOXSIZE, ILI9488_WHITE);
+     } else if (p.x < BOXSIZE*5) {
+       currentcolor = ILI9488_BLUE;
+       tft.drawRect(BOXSIZE*4, 0, BOXSIZE, BOXSIZE, ILI9488_WHITE);
+     } else if (p.x <= BOXSIZE*6) {
+       currentcolor = ILI9488_MAGENTA;
+       tft.drawRect(BOXSIZE*5, 0, BOXSIZE, BOXSIZE, ILI9488_WHITE);
+     }
+
+     if (oldcolor != currentcolor) {
+        if (oldcolor == ILI9488_RED) 
+          tft.fillRect(0, 0, BOXSIZE, BOXSIZE, ILI9488_RED);
+        if (oldcolor == ILI9488_YELLOW) 
+          tft.fillRect(BOXSIZE, 0, BOXSIZE, BOXSIZE, ILI9488_YELLOW);
+        if (oldcolor == ILI9488_GREEN) 
+          tft.fillRect(BOXSIZE*2, 0, BOXSIZE, BOXSIZE, ILI9488_GREEN);
+        if (oldcolor == ILI9488_CYAN) 
+          tft.fillRect(BOXSIZE*3, 0, BOXSIZE, BOXSIZE, ILI9488_CYAN);
+        if (oldcolor == ILI9488_BLUE) 
+          tft.fillRect(BOXSIZE*4, 0, BOXSIZE, BOXSIZE, ILI9488_BLUE);
+        if (oldcolor == ILI9488_MAGENTA) 
+          tft.fillRect(BOXSIZE*5, 0, BOXSIZE, BOXSIZE, ILI9488_MAGENTA);
+     }
+  }
+  if (((p.y-PENRADIUS) > BOXSIZE) && ((p.y+PENRADIUS) < tft.height())) {
+    tft.fillCircle(p.x, p.y, PENRADIUS, currentcolor);
+  }
+}


### PR DESCRIPTION
Slightly modified version of the Adafruit CapTouchPaint example app that is part of the Adafruit_FT6206 library.  THat version was specific to ILI9341 display.  So modified for ILI9488_t3 library.

Tested with BuyDisplay display that has the capacitive touch connected.