### PR TITLE
Fix compile error on T3.2

### DIFF
--- a/ILI9488_t3.h
+++ b/ILI9488_t3.h
@@ -76,6 +76,9 @@ typedef uint8_t RAFB;
 #else
 typedef uint16_t RAFB;
 #endif
+#else 
+// won't be used on processors like T3.2 but allow api exist and not compile error
+typedef uint8_t RAFB;
 #endif
 #endif
 


### PR DESCRIPTION
needed to define RAFB even though frame buffer won't be used