### PR TITLE
looks for header files using #if __hasinclude(...)

### DIFF
--- a/src/ILI9488_t3.h
+++ b/src/ILI9488_t3.h
@@ -48,6 +48,18 @@
 
 #ifndef _ILI9488_t3H_
 #define _ILI9488_t3H_
+#if defined __has_include
+#if __has_include(<extRAM_t4.h>) && defined(ARDUINO_TEENSY41)
+//#include <extRAM_t4.h>
+#define ENABLE_EXT_DMA_UPDATES  // This is only valid for those T4.1 which have external memory. 
+//#pragma message "ILI9488_t3h -  extRAM_T4 enabled EXT DMA frame buffer"
+#endif
+
+#if __has_include(<ILI9488_sketch_options.h>)
+#  include <ILI9488_sketch_options.h>
+//#pragma message "ILI9488_t3h - included ILI9488_sketch_options.h"
+#endif
+#endif
 
 #ifdef __cplusplus
 #include "Arduino.h"


### PR DESCRIPTION
It now looks to see if compiling for T4.1 and the sketch has include extram.h
If so it turns on the using external memory for frame buffer.

Also looks for another header file that if found it inlcudes it as a way for sketches to override the settings, without having to change this library.

Currently the only way I could get this to work is by creating another bogus library where I put the header file such that the Adriuno build process finds it.