### PR TITLE
Fix T4.x builds for Teensyduino release

### DIFF
--- a/examples/Kurts_ILI9488_t3n_FB_and_clip_tests/Kurts_ILI9488_t3n_FB_and_clip_tests.ino
+++ b/examples/Kurts_ILI9488_t3n_FB_and_clip_tests/Kurts_ILI9488_t3n_FB_and_clip_tests.ino
@@ -1,9 +1,6 @@
-#define TRY_EXTMEM
+//#define TRY_EXTMEM
 #ifdef TRY_EXTMEM
-#if defined(ARDUINO_TEENSY41)
-#include <extRAM_t4.h>
-extRAM_t4 ext_mem;
-#else
+#if !defined(ARDUINO_TEENSY41)
 #undef TRY_EXTMEM
 #if defined(ENABLE_EXT_DMA_UPDATES)
 #error "This Version only works with External memory"
@@ -116,7 +113,6 @@ void setup() {
   button.initButton(&tft, 200, 125, 100, 40, ILI9488_GREEN, ILI9488_YELLOW, ILI9488_RED, "UP", 1, 1);
   DBGSerial.println("Just before frist draw Test Screen");
 #ifdef TRY_EXTMEM
-  ext_mem.begin();
   testEXTMem();
 #endif
 
@@ -636,8 +632,8 @@ void drawTextScreen1(bool fOpaque) {
 
 #ifdef TRY_EXTMEM
 void  testEXTMem() {
-#if defined(ENABLE_EXT_DMA_UPDATES)
   elapsedMicros em;
+#if defined(ENABLE_EXT_DMA_UPDATES)
   em = 0;
   tft.setFrameBuffer(extmem_frame_buffer);
   tft.fillScreen(ILI9488_RED);

--- a/src/ILI9488_t3.h
+++ b/src/ILI9488_t3.h
@@ -49,12 +49,6 @@
 #ifndef _ILI9488_t3H_
 #define _ILI9488_t3H_
 #if defined __has_include
-#if __has_include(<extRAM_t4.h>) && defined(ARDUINO_TEENSY41)
-//#include <extRAM_t4.h>
-#define ENABLE_ILI9488_FRAMEBUFFER
-#define ENABLE_EXT_DMA_UPDATES  // This is only valid for those T4.1 which have external memory. 
-//#pragma message "ILI9488_t3h -  extRAM_T4 enabled EXT DMA frame buffer"
-#endif
 
 #if __has_include(<ILI9488_sketch_options.h>)
 #  include <ILI9488_sketch_options.h>
@@ -684,8 +678,8 @@ class ILI9488_t3 : public Print
 	DMASetting   		_dmasettings[6];
 	DMAChannel  		_dmatx;
 	#else
-	static DMASetting 	_dmasettings[2];
-	static DMAChannel  	_dmatx;
+	DMASetting 			_dmasettings[2];
+	DMAChannel  		_dmatx;
 
 	bool fillDMApixelBuffer(uint32_t *buffer_ptr);
 


### PR DESCRIPTION
@mjs513  @PaulStoffregen

Updated the FB and clip test to not default to try to use external memory testing and if the user does enable it, to not use our earlier library.

Also when not using the PSRAM option of the library for T4.1,  make the DMA Settings and DMA Channel objects be part of the class instance instead of static as on T4.1 you could create multiple instances of this object if you are using PSRAM.