### PR TITLE
drawFontChar - Opaque last pixel not marked as last output

### DIFF
--- a/src/ILI9488_t3.cpp
+++ b/src/ILI9488_t3.cpp
@@ -3144,7 +3144,7 @@ void ILI9488_t3::drawFontChar(unsigned int c)
 			while (screen_x-- > 1) {
 				write16BitColor(textbgcolor);
 			}
-			write16BitColor(textbgcolor);
+			write16BitColor(textbgcolor, true);
 			endSPITransaction();
 		}
 


### PR DESCRIPTION
There was an issue up on the forum post:
https://forum.pjrc.com/threads/55735-ILI9488_t3-Support-for-the-ILI9488-on-T3-x-and-beyond?p=249559&viewfull=1#post249559

Where drawing a font character opaque might screw up.  We did not tell the last pixel to output is if it was the last pixel...