### PR TITLE
Fix misleading whitespace compiler warning

### DIFF
--- a/src/ILI9488_t3.cpp
+++ b/src/ILI9488_t3.cpp
@@ -3162,10 +3162,13 @@ int16_t ILI9488_t3::strPixelLen(const char * str, uint16_t cb)
 	if (gfxFont) 
 	{
 		// BUGBUG:: just use the other function for now... May do this for all of them...
-	  int16_t x, y;
-	  uint16_t w, h;
-      if (cb == 0xffff) getTextBounds(str, cursor_x, cursor_y, &x, &y, &w, &h);  // default no count passed in
-      else getTextBounds((const uint8_t *)str, cb, cursor_x, cursor_y, &x, &y, &w, &h);	  return w;
+		int16_t x, y;
+		uint16_t w, h;
+		if (cb == 0xffff)
+			getTextBounds(str, cursor_x, cursor_y, &x, &y, &w, &h);  // default no count passed in
+		else
+			getTextBounds((const uint8_t *)str, cb, cursor_x, cursor_y, &x, &y, &w, &h);
+		return w;
 	}
 
 	uint16_t len=0, maxlen=0;


### PR DESCRIPTION
White space only, no actual code change